### PR TITLE
Changed u & sigma to correspond w/ MATLAB code

### DIFF
--- a/R/AManPG/R/spca.amanpg.R
+++ b/R/AManPG/R/spca.amanpg.R
@@ -99,8 +99,8 @@ spca.amanpg <- function(b, mu, lambda, n, type, maxiter, tol, x0, y0, f_palm, ve
 
       # TODO: sigma may return negative values, how to use sqrt
       eigendecomp <- eigen(Conj(t(tx)) %*% tx)
-      u <- diag(x=eigendecomp$values)
-      sigma <- diag(eigendecomp$vectors)
+      u <- eigendecomp$vectors
+      sigma <- eigendecomp$values
       j <- u %*% diag(sqrt(1 / abs(sigma))) %*% Conj(t(u))  # note use of abs
       x_trial <- tx %*% j
       f_xtrial <- -2 * sum(x_trial * ay)


### PR DESCRIPTION
When looking at the sqrt(1/sigma) problem I referenced the MATLAB code and noticed differences between the MATLAB and R functions. Namely:

- [U, SIGMA] = eig() in MATLAB will return a matrix of the right eigenvectors to U and a diagonal matrix of the eigenvalues to SIGMA. So our 'u' in the R script should correspond to the eigenvectors and our 'sigma' to the eigenvalues 
- diag() in MATLAB will return a column vector of the main diagonal elements of A when given a square matrix so since SIGMA is a diagonal matrix of eigenvalues in MATLAB diag(SIGMA) returns a column vector of the eigenvalues. In the R script, eigendecomp$values returns a vector of the eigenvalues not a diagonal matrix of the eigenvalues so the diag() call is not needed in R

However, after making these fixes I still had the same issue with sqrt(1/sigma) which I am working on.  Let me know if I'm making a dumb mistake here. Also here's the MATLAB documentation about the functions that I referenced:
eig() - https://www.mathworks.com/help/matlab/ref/eig.html#d123e352209
diag() - https://www.mathworks.com/help/matlab/ref/diag.html